### PR TITLE
Force to open() video in binary mode

### DIFF
--- a/python/hwang/decoder.py
+++ b/python/hwang/decoder.py
@@ -13,7 +13,7 @@ class Decoder(object):
         self.video_index = video_index
 
         if isinstance(f_or_path, str):
-            f = open(f_or_path)
+            f = open(f_or_path, 'rb')
         else:
             f = f_or_path
         self.f = f


### PR DESCRIPTION
Fix cases when `open()` is set to be an alias of `codecs.open()`. In those cases, text mode is set to default, which raises UnicodeDecodeError like this:
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9b in position 2: invalid start byte`